### PR TITLE
Add an API endpoint to send an invite email.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 dist/
 node_modules/
 
-DO_NOT_COMMIT.secrets.config.json
+DO_NOT_COMMIT.secrets.config.ts
 config.json
 yarn-error.log

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@google-cloud/storage": "^1.6.0",
     "@koa/cors": "2",
+    "@sendgrid/mail": "^6.2.1",
     "async-busboy": "^0.6.2",
     "coconutjs": "^2.2.0",
     "firebase-admin": "^5.12.0",

--- a/src/app.ts
+++ b/src/app.ts
@@ -47,6 +47,8 @@ const db = admin.firestore();
 const members = db.collection("members");
 const operations = db.collection("operations");
 
+sgMail.setApiKey(sendgridApiKey);
+
 const app = new Koa();
 
 app.use(cors());
@@ -327,7 +329,6 @@ const authenticatedRouter = new Router()
       config.appBase
     ).toString();
 
-    sgMail.setApiKey(sendgridApiKey);
     const msg = {
       to: inviteEmail,
       from: "invites@raha.io",

--- a/src/app.ts
+++ b/src/app.ts
@@ -9,6 +9,7 @@ import Router from "koa-router";
 import bodyParser from "koa-bodyparser";
 import asyncBusboy from "async-busboy";
 import * as coconut from "coconutjs";
+import sgMail from "@sendgrid/mail";
 
 import Storage from "@google-cloud/storage";
 import { getAdmin } from "./firebaseAdmin";
@@ -17,8 +18,10 @@ import { firestore } from "firebase-admin";
 
 // tslint:disable-next-line:no-var-requires
 const config = require("./config/config.json");
-// tslint:disable-next-line:no-var-requires
-const { coconutApiKey } = require("./config/DO_NOT_COMMIT.secrets.config");
+import {
+  coconutApiKey,
+  sendgridApiKey
+} from "./config/DO_NOT_COMMIT.secrets.config";
 
 const TEN_MINUTES = 1000 * 60 * 10;
 
@@ -299,6 +302,54 @@ const authenticatedRouter = new Router()
       ctx.body = "An error occurred while creating this operation.";
       ctx.status = 500;
     }
+  })
+  .post("/api/me/send_invite", async ctx => {
+    const loggedInUid = ctx.state.user.uid;
+    const loggedInMember = await members.doc(loggedInUid).get();
+    const { inviteEmail } = ctx.request.body;
+
+    if (!loggedInMember.exists) {
+      ctx.status = 400;
+      ctx.body = "You must yourself have been invited to Raha to send invites.";
+      return;
+    }
+
+    if (!inviteEmail) {
+      ctx.status = 400;
+      ctx.body = "No invite email included in request.";
+      return;
+    }
+
+    const loggedInFullName = loggedInMember.get("full_name");
+    const loggedInMid = loggedInMember.get("mid");
+    const inviteLink = new URL(
+      `/m/${loggedInMid}/invite`,
+      config.appBase
+    ).toString();
+
+    sgMail.setApiKey(sendgridApiKey);
+    const msg = {
+      to: inviteEmail,
+      from: "invites@raha.io",
+      subject: `${loggedInFullName} invited you to join Raha!`,
+      text:
+        "Raha is the foundation for a global universal basic income. " +
+        "To ensure that only real humans can join, people must be invited " +
+        `by an existing member of the Raha network. ${loggedInFullName} ` +
+        "has invited you to join!\n\n" +
+        `Visit ${inviteLink} to join Raha!`,
+      html:
+        "<span><strong>Raha is the foundation for a global universal basic income.</strong><br /><br />" +
+        "To ensure that only real humans can join, people must be invited " +
+        `by an existing member of the Raha network. ${loggedInFullName} ` +
+        "has invited you to join!</span><br /><br />" +
+        `<span><strong>Visit <a href="${inviteLink}">${inviteLink}</a> to join Raha!</strong></span>`
+    };
+    sgMail.send(msg);
+    ctx.status = 201;
+    ctx.body = {
+      message: "Invite succesfully sent!"
+    };
   });
 
 app.use(authenticatedRouter.routes());

--- a/src/config/prod.config.json
+++ b/src/config/prod.config.json
@@ -1,5 +1,6 @@
 {
   "apiBase": "https://raha-5395e.appspot.com/api/",
+  "appBase": "https://raha.io",
   "privateVideoBucket": "raha-5395e.appspot.com",
   "publicVideoBucket": "raha-video",
   "firebase": {

--- a/src/config/test.config.json
+++ b/src/config/test.config.json
@@ -1,5 +1,6 @@
 {
   "apiBase": "https://raha-test.appspot.com/api",
+  "appBase": "https://next.raha.io",
   "privateVideoBucket": "raha-test.appspot.com",
   "publicVideoBucket": "raha-video-test",
   "firebase": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -193,6 +193,37 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
 
+"@sendgrid/client@^6.2.1":
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/@sendgrid/client/-/client-6.2.1.tgz#f1732f8fbda197c6d11507de6f33efbc1f2cdb31"
+  dependencies:
+    "@sendgrid/helpers" "^6.2.1"
+    "@types/request" "^2.0.3"
+    request "^2.81.0"
+
+"@sendgrid/helpers@^6.2.1":
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/@sendgrid/helpers/-/helpers-6.2.1.tgz#cb7938d8621cc0214076957ec4f4a2b133fa276f"
+  dependencies:
+    chalk "^2.0.1"
+
+"@sendgrid/mail@^6.2.1":
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/@sendgrid/mail/-/mail-6.2.1.tgz#dd8bee0849c6febc5f2534737f2c3a57a875db60"
+  dependencies:
+    "@sendgrid/client" "^6.2.1"
+    "@sendgrid/helpers" "^6.2.1"
+
+"@types/caseless@*":
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/@types/caseless/-/caseless-0.12.1.tgz#9794c69c8385d0192acc471a540d1f8e0d16218a"
+
+"@types/form-data@*":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@types/form-data/-/form-data-2.2.1.tgz#ee2b3b8eaa11c0938289953606b745b738c54b1e"
+  dependencies:
+    "@types/node" "*"
+
 "@types/google-cloud__storage@^1.1.7":
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/@types/google-cloud__storage/-/google-cloud__storage-1.1.7.tgz#f4b568b163cce16314f32f954f5b7d5c9001fa86"
@@ -210,6 +241,19 @@
 "@types/node@^8.0.53", "@types/node@^8.9.4":
   version "8.10.3"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.3.tgz#ee34a5c732703cf45d2fadc163a299a6b2f456c2"
+
+"@types/request@^2.0.3":
+  version "2.47.0"
+  resolved "https://registry.yarnpkg.com/@types/request/-/request-2.47.0.tgz#76a666cee4cb85dcffea6cd4645227926d9e114e"
+  dependencies:
+    "@types/caseless" "*"
+    "@types/form-data" "*"
+    "@types/node" "*"
+    "@types/tough-cookie" "*"
+
+"@types/tough-cookie@*":
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-2.3.2.tgz#e0d481d8bb282ad8a8c9e100ceb72c995fb5e709"
 
 abbrev@1:
   version "1.1.1"
@@ -542,7 +586,7 @@ chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.3.0:
+chalk@^2.0.1, chalk@^2.3.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.0.tgz#a060a297a6b57e15b61ca63ce84995daa0fe6e52"
   dependencies:


### PR DESCRIPTION
Using Sendgrid's API. It doesn't seem like Google cloud has a builtin email sender in the NodeJS Flexible environment.