### PR TITLE
Fix broken encoding flow.

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -88,11 +88,11 @@ async function createCoconutVideoEncodingJob(memberUid, creatorMid) {
   }))[0];
 
   const webhookUrl = new URL(
-    `/members/${memberUid}/notify_video_encoded`,
+    `/api/members/${memberUid}/notify_video_encoded`,
     config.apiBase
   );
   const uploadUrl = new URL(
-    `/members/${memberUid}/upload_video`,
+    `/api/members/${memberUid}/upload_video`,
     config.apiBase
   );
   uploadUrl.searchParams.append("mid", creatorMid);

--- a/src/app.ts
+++ b/src/app.ts
@@ -170,20 +170,7 @@ const publicRouter = new Router()
   })
   /* These endpoints are consumed by coconut. */
   .post("/api/members/:uid/notify_video_encoded", async ctx => {
-    try {
-      const videoRef = getPrivateVideoRef(ctx.state.toMember.id);
-      if ((await videoRef.exists())[0]) {
-        await videoRef.delete();
-      } else {
-        // tslint:disable-next-line:no-console
-        console.warn("We expected a private video file to exist that did not.");
-      }
-      ctx.status = 200;
-    } catch (error) {
-      // tslint:disable-next-line:no-console
-      console.error(error);
-      ctx.status = 500;
-    }
+    ctx.status = 200;
   })
   .post("/api/members/:uid/upload_video", async ctx => {
     try {
@@ -194,8 +181,8 @@ const publicRouter = new Router()
         return;
       }
 
-      const videoRef = getPublicVideoRef(decodeURIComponent(mid));
-      if ((await videoRef.exists())[0]) {
+      const publicVideoRef = getPublicVideoRef(decodeURIComponent(mid));
+      if ((await publicVideoRef.exists())[0]) {
         ctx.status = 400;
         ctx.body =
           "Video already exists at intended storage destination. Cannot overwrite.";
@@ -234,7 +221,16 @@ const publicRouter = new Router()
         multiHash
       });
 
-      await videoRef.save(videoBuf);
+      await publicVideoRef.save(videoBuf);
+
+      const privateVideoRef = getPrivateVideoRef(ctx.state.toMember.id);
+      if ((await privateVideoRef.exists())[0]) {
+        await privateVideoRef.delete();
+      } else {
+        // tslint:disable-next-line:no-console
+        console.warn("We expected a private video file to exist that did not.");
+      }
+
       ctx.status = 201;
     } catch (error) {
       const errorMessage =

--- a/src/config/prod.config.json
+++ b/src/config/prod.config.json
@@ -1,5 +1,5 @@
 {
-  "apiBase": "https://raha-5395e.appspot.com/api/",
+  "apiBase": "https://raha-5395e.appspot.com/",
   "appBase": "https://raha.io",
   "privateVideoBucket": "raha-5395e.appspot.com",
   "publicVideoBucket": "raha-video",

--- a/src/config/test.config.json
+++ b/src/config/test.config.json
@@ -1,5 +1,5 @@
 {
-  "apiBase": "https://raha-test.appspot.com/api",
+  "apiBase": "https://raha-test.appspot.com",
   "appBase": "https://next.raha.io",
   "privateVideoBucket": "raha-test.appspot.com",
   "publicVideoBucket": "raha-video-test",


### PR DESCRIPTION
The webhook urls were being incorrectly constructed.

Also ensures that we don't delete a private video until we've successfully uploaded the encoded video.