### PR TITLE
If videoToken exists in send invite, given a deeplink URL

### DIFF
--- a/src/routes/me/definitions.ts
+++ b/src/routes/me/definitions.ts
@@ -32,7 +32,7 @@ export type SendInviteApiCall = ApiCallDefinition<
   SendInviteApiLocation["method"],
   SendInviteApiLocation["authenticated"],
   void,
-  { inviteEmail: string }
+  { inviteEmail: string; videoToken?: string }
 >;
 export type SendInviteApiResponse = ApiResponseDefinition<
   201,

--- a/src/routes/me/index.ts
+++ b/src/routes/me/index.ts
@@ -49,7 +49,7 @@ export const sendInvite = (
     const loggedInMemberId = loggedInMemberToken.uid;
     const loggedInMember = await members.doc(loggedInMemberId).get();
 
-    const { inviteEmail } = call.body;
+    const { inviteEmail, videoToken } = call.body;
 
     if (!loggedInMember.exists) {
       throw new ApiError(
@@ -67,10 +67,14 @@ export const sendInvite = (
 
     const loggedInFullName = loggedInMember.get("full_name");
     const loggedInUsername = loggedInMember.get("username");
-    const inviteLink = new URL(
-      `/m/${loggedInUsername}/invite`,
-      config.appBase
-    ).toString();
+
+    // If there is already a videoToken, give them the deeplink format.
+    const inviteLink = videoToken
+      ? new URL(
+          `/invite/referrer=${loggedInUsername}&token=${videoToken}`,
+          `https://raha.app`
+        ).toString()
+      : new URL(`/m/${loggedInUsername}/invite`, config.appBase).toString();
 
     const msg = {
       to: inviteEmail,


### PR DESCRIPTION
The mobile client will send up a videoToken if the inviter went through the invite flow. If this is sent, send the URL for deeplinking.

Format of the link is:
`https://raha.app/invite/referrer=tina.roh.7659&token=abcde1234`