### PR TITLE
Duplicate request_invite to web_request_invite.

### DIFF
--- a/src/client/members/requestInvite.ts
+++ b/src/client/members/requestInvite.ts
@@ -15,7 +15,7 @@ import { callApi } from "../callApi";
  * existing member
  * @param username New username for the new member. Must be unique
  */
-export function webRequestInvite(
+export function requestInvite(
   apiBase: string,
   authToken: string,
   memberId: MemberId,

--- a/src/client/members/requestInvite.ts
+++ b/src/client/members/requestInvite.ts
@@ -1,0 +1,34 @@
+import { MemberId } from "../../shared/models/identifiers";
+import {
+  RequestInviteApiEndpoint,
+  RequestInviteApiCall,
+  requestInviteApiLocation
+} from "../../shared/routes/members/definitions";
+
+import { callApi } from "../callApi";
+
+/**
+ * API call for a non-member to request an invite from an existing one.
+ * @param memberId Member to request invite from
+ * @param fullName Full name of new member
+ * @param videoUrl URL of invite video, of the new member being invited by the
+ * existing member
+ * @param username New username for the new member. Must be unique
+ */
+export function webRequestInvite(
+  apiBase: string,
+  authToken: string,
+  memberId: MemberId,
+  fullName: string,
+  videoUrl: string,
+  username: string
+) {
+  const apiCall: RequestInviteApiCall = {
+    location: requestInviteApiLocation,
+    request: {
+      params: { memberId },
+      body: { fullName, videoUrl, username }
+    }
+  };
+  return callApi<RequestInviteApiEndpoint>(apiBase, apiCall, authToken);
+}

--- a/src/client/members/webRequestInvite.ts
+++ b/src/client/members/webRequestInvite.ts
@@ -1,8 +1,8 @@
 import { MemberId } from "../../shared/models/identifiers";
 import {
-  RequestInviteApiEndpoint,
-  RequestInviteApiCall,
-  requestInviteApiLocation
+  WebRequestInviteApiEndpoint,
+  WebRequestInviteApiCall,
+  webRequestInviteApiLocation
 } from "../../shared/routes/members/definitions";
 
 import { callApi } from "../callApi";
@@ -15,7 +15,7 @@ import { callApi } from "../callApi";
  * existing member
  * @param username New username for the new member. Must be unique
  */
-export function requestInvite(
+export function webRequestInvite(
   apiBase: string,
   authToken: string,
   memberId: MemberId,
@@ -23,12 +23,12 @@ export function requestInvite(
   videoUrl: string,
   username: string
 ) {
-  const apiCall: RequestInviteApiCall = {
-    location: requestInviteApiLocation,
+  const apiCall: WebRequestInviteApiCall = {
+    location: webRequestInviteApiLocation,
     request: {
       params: { memberId },
       body: { fullName, videoUrl, username }
     }
   };
-  return callApi<RequestInviteApiEndpoint>(apiBase, apiCall, authToken);
+  return callApi<WebRequestInviteApiEndpoint>(apiBase, apiCall, authToken);
 }

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -30,7 +30,8 @@ import { listOperationsApiLocation } from "../shared/routes/operations/definitio
 import {
   trustMemberApiLocation,
   webRequestInviteApiLocation,
-  giveApiLocation
+  giveApiLocation,
+  requestInviteApiLocation
 } from "../shared/routes/members/definitions";
 import {
   sendInviteApiLocation,
@@ -106,6 +107,16 @@ const apiRoutes: Array<RouteHandler<ApiLocation>> = [
   {
     location: webRequestInviteApiLocation,
     handler: membersRoutes.webRequestInvite(
+      config,
+      storage,
+      coconutApiKey,
+      membersCollection,
+      operationsCollection
+    )
+  },
+  {
+    location: requestInviteApiLocation,
+    handler: membersRoutes.requestInvite(
       config,
       storage,
       coconutApiKey,

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -29,7 +29,7 @@ import { ApiLocation } from "../shared/types/ApiEndpoint/ApiCall";
 import { listOperationsApiLocation } from "../shared/routes/operations/definitions";
 import {
   trustMemberApiLocation,
-  requestInviteApiLocation,
+  webRequestInviteApiLocation,
   giveApiLocation
 } from "../shared/routes/members/definitions";
 import {
@@ -104,8 +104,8 @@ const apiRoutes: Array<RouteHandler<ApiLocation>> = [
     handler: membersRoutes.trust(db, membersCollection, operationsCollection)
   },
   {
-    location: requestInviteApiLocation,
-    handler: membersRoutes.requestInvite(
+    location: webRequestInviteApiLocation,
+    handler: membersRoutes.webRequestInvite(
       config,
       storage,
       coconutApiKey,

--- a/src/server/config/test.config.ts
+++ b/src/server/config/test.config.ts
@@ -18,6 +18,6 @@ export const config: Config = {
     messagingServiceSid: "MG90714479d4b405a524a4a6ccd2f9bf7d",
     fromNumber: "+16572377242"
   },
-  debugNumbers: [],
+  debugNumbers: ["+14405555555"],
   discourseBase: "https://discuss.raha.app/"
 };

--- a/src/server/routes/members/index.ts
+++ b/src/server/routes/members/index.ts
@@ -22,7 +22,8 @@ import { Context } from "koa";
 import {
   GiveApiEndpoint,
   WebRequestInviteApiEndpoint,
-  TrustMemberApiEndpoint
+  TrustMemberApiEndpoint,
+  RequestInviteApiEndpoint
 } from "../../../shared/routes/members/definitions";
 import { HttpApiError } from "../../../shared/errors/HttpApiError";
 import { AlreadyRequestedError } from "../../../shared/errors/RahaApiError/members/requestInvite/AlreadyRequestedError";
@@ -289,7 +290,7 @@ export const requestInvite = (
   membersCollection: CollectionReference,
   operationsCollection: CollectionReference
 ) =>
-  createApiRoute<WebRequestInviteApiEndpoint>(
+  createApiRoute<RequestInviteApiEndpoint>(
     async (call, loggedInMemberToken) => {
       const loggedInUid = loggedInMemberToken.uid;
       const loggedInMemberRef = membersCollection.doc(loggedInUid);

--- a/src/server/routes/members/index.ts
+++ b/src/server/routes/members/index.ts
@@ -21,7 +21,7 @@ import { getMemberById } from "../../../shared/models/Member";
 import { Context } from "koa";
 import {
   GiveApiEndpoint,
-  RequestInviteApiEndpoint,
+  WebRequestInviteApiEndpoint,
   TrustMemberApiEndpoint
 } from "../../../shared/routes/members/definitions";
 import { HttpApiError } from "../../../shared/errors/HttpApiError";
@@ -213,14 +213,14 @@ export const uploadVideo = (
   ctx.status = 201;
 };
 
-export const requestInvite = (
+export const webRequestInvite = (
   config: Config,
   storage: BucketStorage,
   coconutApiKey: string,
   membersCollection: CollectionReference,
   operationsCollection: CollectionReference
 ) =>
-  createApiRoute<RequestInviteApiEndpoint>(
+  createApiRoute<WebRequestInviteApiEndpoint>(
     async (call, loggedInMemberToken) => {
       const loggedInUid = loggedInMemberToken.uid;
       const loggedInMemberRef = membersCollection.doc(loggedInUid);

--- a/src/shared/errors/RahaApiError/MissingParamsError.ts
+++ b/src/shared/errors/RahaApiError/MissingParamsError.ts
@@ -1,7 +1,7 @@
 import * as httpStatus from "http-status";
 
 import { RahaApiError } from ".";
-import { getHttpStatusText } from "../../../shared/types/helpers/http";
+import { getHttpStatusText } from "../../types/helpers/http";
 
 export const ERROR_CODE = "notFound";
 export interface MissingParamsErrorBody {

--- a/src/shared/errors/RahaApiError/NotFoundError.ts
+++ b/src/shared/errors/RahaApiError/NotFoundError.ts
@@ -1,7 +1,7 @@
 import * as httpStatus from "http-status";
 
 import { RahaApiError } from ".";
-import { getHttpStatusText } from "../../../shared/types/helpers/http";
+import { getHttpStatusText } from "../../types/helpers/http";
 
 export const ERROR_CODE = "notFound";
 export interface NotFoundErrorBody {

--- a/src/shared/errors/RahaApiError/ServerError.ts
+++ b/src/shared/errors/RahaApiError/ServerError.ts
@@ -1,7 +1,7 @@
 import * as httpStatus from "http-status";
 
 import { RahaApiError } from ".";
-import { getHttpStatusText } from "../../../shared/types/helpers/http";
+import { getHttpStatusText } from "../../types/helpers/http";
 
 export const ERROR_CODE = "serverError";
 export interface ServerErrorBody {

--- a/src/shared/errors/RahaApiError/UnauthorizedError.ts
+++ b/src/shared/errors/RahaApiError/UnauthorizedError.ts
@@ -1,7 +1,7 @@
 import * as httpStatus from "http-status";
 
 import { RahaApiError } from ".";
-import { getHttpStatusText } from "../../../shared/types/helpers/http";
+import { getHttpStatusText } from "../../types/helpers/http";
 
 export const ERROR_CODE = "unauthorized";
 export interface UnauthorizedErrorBody {

--- a/src/shared/errors/RahaApiError/index.ts
+++ b/src/shared/errors/RahaApiError/index.ts
@@ -1,5 +1,5 @@
 import { HttpApiError } from "../HttpApiError";
-import { HttpStatusCode } from "../../../shared/types/helpers/http";
+import { HttpStatusCode } from "../../types/helpers/http";
 
 /**
  * Error that corresponds to a particular Raha API error code and response

--- a/src/shared/errors/RahaApiError/me/mint/MintInvalidTypeError.ts
+++ b/src/shared/errors/RahaApiError/me/mint/MintInvalidTypeError.ts
@@ -1,8 +1,8 @@
 import * as httpStatus from "http-status";
 
 import { RahaApiError } from "../..";
-import { MintType } from "../../../../../shared/models/Operation";
-import { EnumValues } from "../../../../../../node_modules/enum-values";
+import { MintType } from "../../../../models/Operation";
+import { EnumValues } from "enum-values";
 
 export const ERROR_CODE = "mint.invalidType";
 export interface MintInvalidTypeErrorBody {

--- a/src/shared/errors/RahaApiError/me/mint/referral/AlreadyMintedError.ts
+++ b/src/shared/errors/RahaApiError/me/mint/referral/AlreadyMintedError.ts
@@ -1,7 +1,7 @@
 import * as httpStatus from "http-status";
 
 import { RahaApiError } from "../../..";
-import { MemberId } from "../../../../../../shared/models/identifiers";
+import { MemberId } from "../../../../../models/identifiers";
 
 export const ERROR_CODE = "mint.referral.alreadyMinted";
 export interface AlreadyMintedErrorBody {

--- a/src/shared/errors/RahaApiError/me/mint/referral/NotInvitedError.ts
+++ b/src/shared/errors/RahaApiError/me/mint/referral/NotInvitedError.ts
@@ -1,7 +1,7 @@
 import * as httpStatus from "http-status";
 
 import { RahaApiError } from "../../..";
-import { MemberId } from "../../../../../../shared/models/identifiers";
+import { MemberId } from "../../../../../models/identifiers";
 
 export const ERROR_CODE = "mint.referral.notInvited";
 export interface NotInvitedErrorBody {

--- a/src/shared/errors/RahaApiError/me/mint/referral/NotTrustedError.ts
+++ b/src/shared/errors/RahaApiError/me/mint/referral/NotTrustedError.ts
@@ -1,7 +1,7 @@
 import * as httpStatus from "http-status";
 
 import { RahaApiError } from "../../..";
-import { MemberId } from "../../../../../../shared/models/identifiers";
+import { MemberId } from "../../../../../models/identifiers";
 
 export const ERROR_CODE = "mint.referral.notTrusted";
 export interface NotTrustedErrorBody {

--- a/src/shared/routes/members/definitions.ts
+++ b/src/shared/routes/members/definitions.ts
@@ -49,6 +49,37 @@ export type WebRequestInviteApiEndpoint = ApiEndpointDefinition<
 /*
  * TODO: find a better way to narrow the types precisely than this repetitive type declaration
  */
+export type RequestInviteApiLocation = ApiLocationDefinition<
+  ApiEndpointUri.REQUEST_INVITE,
+  HttpVerb.POST,
+  true
+>;
+export const requestInviteApiLocation: RequestInviteApiLocation = {
+  uri: ApiEndpointUri.REQUEST_INVITE,
+  method: HttpVerb.POST,
+  authenticated: true
+};
+export type RequestInviteApiCall = ApiCallDefinition<
+  RequestInviteApiLocation["uri"],
+  RequestInviteApiLocation["method"],
+  RequestInviteApiLocation["authenticated"],
+  { memberId: MemberId },
+  { fullName: string; videoUrl: string; username: string }
+>;
+export type RequestInviteApiResponse = ApiResponseDefinition<
+  201,
+  OperationApiResponseBody
+>;
+
+export type RequestInviteApiEndpoint = ApiEndpointDefinition<
+  ApiEndpointName.REQUEST_INVITE,
+  RequestInviteApiCall,
+  RequestInviteApiResponse
+>;
+
+/*
+ * TODO: find a better way to narrow the types precisely than this repetitive type declaration
+ */
 export type TrustMemberApiLocation = ApiLocationDefinition<
   ApiEndpointUri.TRUST_MEMBER,
   HttpVerb.POST,

--- a/src/shared/routes/members/definitions.ts
+++ b/src/shared/routes/members/definitions.ts
@@ -18,32 +18,32 @@ import { ApiLocationDefinition } from "../../types/ApiEndpoint/ApiCall";
 /*
  * TODO: find a better way to narrow the types precisely than this repetitive type declaration
  */
-export type RequestInviteApiLocation = ApiLocationDefinition<
-  ApiEndpointUri.REQUEST_INVITE,
+export type WebRequestInviteApiLocation = ApiLocationDefinition<
+  ApiEndpointUri.WEB_REQUEST_INVITE,
   HttpVerb.POST,
   true
 >;
-export const requestInviteApiLocation: RequestInviteApiLocation = {
-  uri: ApiEndpointUri.REQUEST_INVITE,
+export const webRequestInviteApiLocation: WebRequestInviteApiLocation = {
+  uri: ApiEndpointUri.WEB_REQUEST_INVITE,
   method: HttpVerb.POST,
   authenticated: true
 };
-export type RequestInviteApiCall = ApiCallDefinition<
-  RequestInviteApiLocation["uri"],
-  RequestInviteApiLocation["method"],
-  RequestInviteApiLocation["authenticated"],
+export type WebRequestInviteApiCall = ApiCallDefinition<
+  WebRequestInviteApiLocation["uri"],
+  WebRequestInviteApiLocation["method"],
+  WebRequestInviteApiLocation["authenticated"],
   { memberId: MemberId },
   { fullName: string; videoUrl: string; username: string }
 >;
-export type RequestInviteApiResponse = ApiResponseDefinition<
+export type WebRequestInviteApiResponse = ApiResponseDefinition<
   201,
   OperationApiResponseBody
 >;
 
-export type RequestInviteApiEndpoint = ApiEndpointDefinition<
-  ApiEndpointName.REQUEST_INVITE,
-  RequestInviteApiCall,
-  RequestInviteApiResponse
+export type WebRequestInviteApiEndpoint = ApiEndpointDefinition<
+  ApiEndpointName.WEB_REQUEST_INVITE,
+  WebRequestInviteApiCall,
+  WebRequestInviteApiResponse
 >;
 
 /*

--- a/src/shared/types/ApiEndpoint/index.ts
+++ b/src/shared/types/ApiEndpoint/index.ts
@@ -7,6 +7,7 @@ import { ApiResponse } from "./ApiResponse";
 import {
   GiveApiEndpoint,
   WebRequestInviteApiEndpoint,
+  RequestInviteApiEndpoint,
   TrustMemberApiEndpoint
 } from "../../routes/members/definitions";
 import {
@@ -25,6 +26,7 @@ export enum ApiEndpointName {
   TRUST_MEMBER = "TRUST_MEMBER",
   GET_OPERATIONS = "GET_OPERATIONS",
   WEB_REQUEST_INVITE = "WEB_REQUEST_INVITE",
+  REQUEST_INVITE = "REQUEST_INVITE",
   SEND_INVITE = "SEND_INVITE",
   MINT = "MINT",
   GIVE = "GIVE",
@@ -37,6 +39,7 @@ export enum ApiEndpointUri {
   TRUST_MEMBER = "members/:memberId/trust",
   GET_OPERATIONS = "operations",
   WEB_REQUEST_INVITE = "members/:memberId/web_request_invite",
+  REQUEST_INVITE = "members/:memberId/request_invite",
   SEND_INVITE = "me/send_invite",
   MINT = "me/mint",
   GIVE = "members/:memberId/give",
@@ -70,6 +73,7 @@ export type ApiEndpoint =
   | TrustMemberApiEndpoint
   | ListOperationsApiEndpoint
   | WebRequestInviteApiEndpoint
+  | RequestInviteApiEndpoint
   | SendInviteApiEndpoint
   | GiveApiEndpoint
   | MintApiEndpoint

--- a/src/shared/types/ApiEndpoint/index.ts
+++ b/src/shared/types/ApiEndpoint/index.ts
@@ -6,7 +6,7 @@ import { ApiResponse } from "./ApiResponse";
 
 import {
   GiveApiEndpoint,
-  RequestInviteApiEndpoint,
+  WebRequestInviteApiEndpoint,
   TrustMemberApiEndpoint
 } from "../../routes/members/definitions";
 import {
@@ -24,7 +24,7 @@ import { SSODiscourseApiEndpoint } from "../../routes/sso/definitions";
 export enum ApiEndpointName {
   TRUST_MEMBER = "TRUST_MEMBER",
   GET_OPERATIONS = "GET_OPERATIONS",
-  REQUEST_INVITE = "REQUEST_INVITE",
+  WEB_REQUEST_INVITE = "WEB_REQUEST_INVITE",
   SEND_INVITE = "SEND_INVITE",
   MINT = "MINT",
   GIVE = "GIVE",
@@ -36,7 +36,7 @@ export enum ApiEndpointName {
 export enum ApiEndpointUri {
   TRUST_MEMBER = "members/:memberId/trust",
   GET_OPERATIONS = "operations",
-  REQUEST_INVITE = "members/:memberId/request_invite",
+  WEB_REQUEST_INVITE = "members/:memberId/web_request_invite",
   SEND_INVITE = "me/send_invite",
   MINT = "me/mint",
   GIVE = "members/:memberId/give",
@@ -69,7 +69,7 @@ export interface ApiEndpointDefinition<
 export type ApiEndpoint =
   | TrustMemberApiEndpoint
   | ListOperationsApiEndpoint
-  | RequestInviteApiEndpoint
+  | WebRequestInviteApiEndpoint
   | SendInviteApiEndpoint
   | GiveApiEndpoint
   | MintApiEndpoint


### PR DESCRIPTION
We want to modify the `request_invite` endpoint to be used by the mobile app since it will be taking in different params and won't require Coconut encoding, and move web `request_invite` to `web_request_invite`. 

This change copies over all of `request_invite` and duplicates it. Changes to `request_invite` to make it compatible with mobile invite flow will be on a separate PR.

@rahulgi will follow up with a change to make raha-web-app use this shared client library's `web_request_invite` endpoint.