### PR TITLE
Change request_invite to move the invite video over to GCS public video.

### DIFF
--- a/src/client/members/requestInvite.ts
+++ b/src/client/members/requestInvite.ts
@@ -11,8 +11,8 @@ import { callApi } from "../callApi";
  * API call for a non-member to request an invite from an existing one.
  * @param memberId Member to request invite from
  * @param fullName Full name of new member
- * @param videoUrl URL of invite video, of the new member being invited by the
- * existing member
+ * @param videoToken Optional video token of the invite, of the new member being invited by the
+ * existing member. If not provided, the video will be pulled from private-video.
  * @param username New username for the new member. Must be unique
  */
 export function requestInvite(
@@ -20,14 +20,14 @@ export function requestInvite(
   authToken: string,
   memberId: MemberId,
   fullName: string,
-  videoUrl: string,
-  username: string
+  username: string,
+  videoToken?: string
 ) {
   const apiCall: RequestInviteApiCall = {
     location: requestInviteApiLocation,
     request: {
       params: { memberId },
-      body: { fullName, videoUrl, username }
+      body: { fullName, username, videoToken }
     }
   };
   return callApi<RequestInviteApiEndpoint>(apiBase, apiCall, authToken);

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -119,7 +119,6 @@ const apiRoutes: Array<RouteHandler<ApiLocation>> = [
     handler: membersRoutes.requestInvite(
       config,
       storage,
-      coconutApiKey,
       membersCollection,
       operationsCollection
     )

--- a/src/shared/routes/members/definitions.ts
+++ b/src/shared/routes/members/definitions.ts
@@ -64,7 +64,7 @@ export type RequestInviteApiCall = ApiCallDefinition<
   RequestInviteApiLocation["method"],
   RequestInviteApiLocation["authenticated"],
   { memberId: MemberId },
-  { fullName: string; videoUrl: string; username: string }
+  { fullName: string; username: string; videoToken?: string }
 >;
 export type RequestInviteApiResponse = ApiResponseDefinition<
   201,


### PR DESCRIPTION
If the videoToken is present, look in "invite-video", otherwise look into "private-video". Don't do Coconut encoding.

Before merging/deploying:
- [x] Make sure web app is migrated to use web_request_invite