### PR TITLE
Relax requirements for thumbnail existence.

### DIFF
--- a/packages/server/src/routes/members/index.ts
+++ b/packages/server/src/routes/members/index.ts
@@ -126,14 +126,17 @@ async function movePrivateVideoToPublicVideo(
   }
 
   await (removeOriginal
-    ? Promise.all([
-        privateVideoRef.move(publicVideoRef),
-        privateVideoThumbnailRef.move(publicThumbnailRef)
-      ])
-    : Promise.all([
-        privateVideoRef.copy(publicVideoRef),
-        privateVideoThumbnailRef.copy(publicThumbnailRef)
-      ]));
+    ? Promise.all([privateVideoRef.move(publicVideoRef)])
+    : Promise.all([privateVideoRef.copy(publicVideoRef)]));
+
+  // Until the iOS app gets updated and starts generating thumbnails, we
+  // cannot throw an error on the thumbnail not existing.
+  // TODO: Throw an error on non-existent thumbnail once the iOS app gets updated.
+  if (privateVideoThumbnailRef.exists()) {
+    (await removeOriginal)
+      ? privateVideoThumbnailRef.move(publicThumbnailRef)
+      : privateVideoThumbnailRef.copy(publicThumbnailRef);
+  }
 
   return publicVideoRef;
 }
@@ -179,12 +182,7 @@ async function movePrivateVideoToPublicInviteVideo(
     .bucket(config.privateVideoBucket)
     .file(`private-video/${videoToken}/thumbnail.jpg`);
 
-  if (
-    (await Promise.all([
-      privateVideoRef.exists(),
-      privateThumbnailRef.exists()
-    ])).find(x => !x[0])
-  ) {
+  if ((await Promise.all([privateVideoRef.exists()])).find(x => !x[0])) {
     throw new HttpApiError(
       httpStatus.BAD_REQUEST,
       "Private video does not exist at expected location. Cannot move.",
@@ -193,14 +191,17 @@ async function movePrivateVideoToPublicInviteVideo(
   }
 
   await (removeOriginal
-    ? Promise.all([
-        privateVideoRef.move(publicVideoRef),
-        privateThumbnailRef.move(publicThumbnailRef)
-      ])
-    : Promise.all([
-        privateVideoRef.copy(publicVideoRef),
-        privateThumbnailRef.copy(publicThumbnailRef)
-      ]));
+    ? Promise.all([privateVideoRef.move(publicVideoRef)])
+    : Promise.all([privateVideoRef.copy(publicVideoRef)]));
+
+  // Until the iOS app gets updated and starts generating thumbnails, we
+  // cannot throw an error on the thumbnail not existing.
+  // TODO: Throw an error on non-existent thumbnail once the iOS app gets updated.
+  if (privateThumbnailRef.exists()) {
+    (await removeOriginal)
+      ? privateThumbnailRef.move(publicThumbnailRef)
+      : privateThumbnailRef.copy(publicThumbnailRef);
+  }
 
   return publicVideoRef;
 }

--- a/packages/server/src/routes/members/index.ts
+++ b/packages/server/src/routes/members/index.ts
@@ -126,8 +126,8 @@ async function movePrivateVideoToPublicVideo(
   }
 
   await (removeOriginal
-    ? Promise.all([privateVideoRef.move(publicVideoRef)])
-    : Promise.all([privateVideoRef.copy(publicVideoRef)]));
+    ? privateVideoRef.move(publicVideoRef)
+    : privateVideoRef.copy(publicVideoRef));
 
   // Until the iOS app gets updated and starts generating thumbnails, we
   // cannot throw an error on the thumbnail not existing.
@@ -182,7 +182,7 @@ async function movePrivateVideoToPublicInviteVideo(
     .bucket(config.privateVideoBucket)
     .file(`private-video/${videoToken}/thumbnail.jpg`);
 
-  if ((await Promise.all([privateVideoRef.exists()])).find(x => !x[0])) {
+  if (!(await privateVideoRef.exists())[0]) {
     throw new HttpApiError(
       httpStatus.BAD_REQUEST,
       "Private video does not exist at expected location. Cannot move.",
@@ -191,8 +191,8 @@ async function movePrivateVideoToPublicInviteVideo(
   }
 
   await (removeOriginal
-    ? Promise.all([privateVideoRef.move(publicVideoRef)])
-    : Promise.all([privateVideoRef.copy(publicVideoRef)]));
+    ? privateVideoRef.move(publicVideoRef)
+    : privateVideoRef.copy(publicVideoRef));
 
   // Until the iOS app gets updated and starts generating thumbnails, we
   // cannot throw an error on the thumbnail not existing.

--- a/packages/server/src/routes/members/index.ts
+++ b/packages/server/src/routes/members/index.ts
@@ -133,9 +133,9 @@ async function movePrivateVideoToPublicVideo(
   // cannot throw an error on the thumbnail not existing.
   // TODO: Throw an error on non-existent thumbnail once the iOS app gets updated.
   if (privateVideoThumbnailRef.exists()) {
-    (await removeOriginal)
+    await (removeOriginal
       ? privateVideoThumbnailRef.move(publicThumbnailRef)
-      : privateVideoThumbnailRef.copy(publicThumbnailRef);
+      : privateVideoThumbnailRef.copy(publicThumbnailRef));
   }
 
   return publicVideoRef;
@@ -198,9 +198,9 @@ async function movePrivateVideoToPublicInviteVideo(
   // cannot throw an error on the thumbnail not existing.
   // TODO: Throw an error on non-existent thumbnail once the iOS app gets updated.
   if (privateThumbnailRef.exists()) {
-    (await removeOriginal)
+    await (removeOriginal
       ? privateThumbnailRef.move(publicThumbnailRef)
-      : privateThumbnailRef.copy(publicThumbnailRef);
+      : privateThumbnailRef.copy(publicThumbnailRef));
   }
 
   return publicVideoRef;


### PR DESCRIPTION
Allow videos to not have thumbnails. Do not throw an error if the
thumbnail does not exist, and only copy it if it does.

This is to stop the iOS app from breaking. Once the iOS app is updated
to generate thumbnails, we can revert this change.