### PR TITLE
Add email address from CREATE_MEMBER to SendGrid

### DIFF
--- a/packages/client/src/members/createMember.ts
+++ b/packages/client/src/members/createMember.ts
@@ -13,6 +13,8 @@ import { callApi } from "../callApi";
  * @param videoToken Video token of the invite, of the new member either identifying themselves or
  * being invited by the existing member.
  * @param inviteToken: Token identifying associated invite operation.
+ * @param subscribeToNewsletter Whether user wants to be subscribed to the
+ * update newsletter
  */
 export function createMember(
   apiBase: string,
@@ -21,7 +23,8 @@ export function createMember(
   emailAddress: string,
   username: string,
   videoToken: string,
-  inviteToken?: string
+  inviteToken?: string,
+  subscribeToNewsletter?: boolean
 ) {
   const apiCall: CreateMemberApiCall = {
     location: createMemberApiLocation,
@@ -32,7 +35,8 @@ export function createMember(
         username,
         emailAddress,
         videoToken,
-        inviteToken
+        inviteToken,
+        subscribeToNewsletter
       }
     }
   };

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -14,6 +14,7 @@
     "@google-cloud/storage": "^1.6.0",
     "@koa/cors": "2",
     "@raha/api-shared": "^0.1.13",
+    "@sendgrid/client": "^6.3.0",
     "@sendgrid/mail": "^6.2.1",
     "@types/big.js": "^4.0.4",
     "@types/url-join": "^0.8.2",

--- a/packages/server/src/app.ts
+++ b/packages/server/src/app.ts
@@ -7,6 +7,7 @@ import * as bodyParser from "koa-bodyparser";
 import * as cors from "@koa/cors";
 import * as Router from "koa-router";
 import * as sgMail from "@sendgrid/mail";
+import * as sgClient from "@sendgrid/client";
 import { Firestore } from "@google-cloud/firestore";
 import * as adminLib from "firebase-admin";
 
@@ -68,6 +69,7 @@ const operationsCollection = db.collection("operations");
 const fmcTokensCollection = db.collection("firebaseCloudMessagingTokens");
 
 sgMail.setApiKey(sendgridApiKey);
+sgClient.setApiKey(sendgridApiKey);
 
 const app = new Koa();
 
@@ -121,7 +123,8 @@ const apiRoutes: Array<RouteHandler<ApiLocation>> = [
       messaging,
       membersCollection,
       operationsCollection,
-      fmcTokensCollection
+      fmcTokensCollection,
+      sgClient
     )
   },
   {

--- a/packages/server/src/config/prod.config.ts
+++ b/packages/server/src/config/prod.config.ts
@@ -16,6 +16,10 @@ export const config = {
     messagingServiceSid: "MG90714479d4b405a524a4a6ccd2f9bf7d",
     fromNumber: "+16572377242"
   },
+  sendGrid: {
+    appRegistrationListId: "5460644",
+    updateNewsletterListId: "5460649"
+  },
   debugNumbers: ["+14255555555", "+14406231005", "+13088288942"],
   discourseBase: "https://discuss.raha.app/"
 };

--- a/packages/server/src/config/test.config.ts
+++ b/packages/server/src/config/test.config.ts
@@ -18,6 +18,10 @@ export const config: Config = {
     messagingServiceSid: "MG90714479d4b405a524a4a6ccd2f9bf7d",
     fromNumber: "+16572377242"
   },
+  sendGrid: {
+    appRegistrationListId: "5460644",
+    updateNewsletterListId: "5460649"
+  },
   debugNumbers: [
     "+14405555555",
     "+14406231005",

--- a/packages/server/src/routes/members/createMember.ts
+++ b/packages/server/src/routes/members/createMember.ts
@@ -425,6 +425,7 @@ export const createMember = (
       config,
       sgClient,
       call.body.emailAddress,
+      call.body.fullName,
       call.body.subscribeToNewsletter
     );
 
@@ -438,6 +439,7 @@ async function _addEmailToMailingLists(
   config: Config,
   sgClient: SgClient,
   emailAddress: string,
+  fullName: string,
   subscribeToNewsletter?: boolean
 ) {
   // Don't fail CREATE_MEMBER due to SendGrid API.
@@ -445,7 +447,7 @@ async function _addEmailToMailingLists(
     const response = await sgClient.request({
       method: "POST",
       url: "/v3/contactdb/recipients",
-      body: [{ email: emailAddress }]
+      body: [{ email: emailAddress, full_name: fullName }]
     });
 
     const persisted_recipients = response[1].persisted_recipients;

--- a/packages/server/src/routes/members/createMember.ts
+++ b/packages/server/src/routes/members/createMember.ts
@@ -422,6 +422,7 @@ export const createMember = (
     });
 
     _addEmailToMailingLists(
+      config,
       sgClient,
       call.body.emailAddress,
       call.body.subscribeToNewsletter
@@ -434,6 +435,7 @@ export const createMember = (
   });
 
 async function _addEmailToMailingLists(
+  config: Config,
   sgClient: SgClient,
   emailAddress: string,
   subscribeToNewsletter?: boolean
@@ -452,17 +454,19 @@ async function _addEmailToMailingLists(
     }
     const recipient_id = persisted_recipients[0];
 
-    const APP_REGISTRATION = "5460644";
     await sgClient.request({
       method: "POST",
-      url: `/v3/contactdb/lists/${APP_REGISTRATION}/recipients/${recipient_id}`
+      url: `/v3/contactdb/lists/${
+        config.sendGrid.appRegistrationListId
+      }/recipients/${recipient_id}`
     });
 
     if (subscribeToNewsletter) {
-      const UPDATE_NEWSLETTER = "5460649";
       await sgClient.request({
         method: "POST",
-        url: `/v3/contactdb/lists/${UPDATE_NEWSLETTER}/recipients/${recipient_id}`
+        url: `/v3/contactdb/lists/${
+          config.sendGrid.updateNewsletterListId
+        }/recipients/${recipient_id}`
       });
     }
   } catch (exception) {

--- a/packages/shared/src/routes/members/definitions.ts
+++ b/packages/shared/src/routes/members/definitions.ts
@@ -127,6 +127,7 @@ export type CreateMemberApiCall = ApiCallDefinition<
     videoToken: string;
     username: string;
     inviteToken?: string;
+    subscribeToNewsletter?: boolean;
   }
 >;
 export type CreateMemberApiResponse = ApiResponseDefinition<

--- a/yarn.lock
+++ b/yarn.lock
@@ -199,7 +199,7 @@
 
 "@sendgrid/client@^6.3.0":
   version "6.3.0"
-  resolved "https://registry.npmjs.org/@sendgrid/client/-/client-6.3.0.tgz#25c34b11bec392ab43ca7e52fb35e4105fb00901"
+  resolved "https://registry.yarnpkg.com/@sendgrid/client/-/client-6.3.0.tgz#25c34b11bec392ab43ca7e52fb35e4105fb00901"
   dependencies:
     "@sendgrid/helpers" "^6.3.0"
     "@types/request" "^2.0.3"


### PR DESCRIPTION
Add email as recipient to SendGrid, the "App Registration" campaign list, and optionally to "Newsletter" list

One thing to note: Right now I only log if SendGrid fails and don't fail CREATE_MEMBER altogether. Is there a better way to handle this?